### PR TITLE
fix: resolve 'final_result' tool execution issue in Digitone agent

### DIFF
--- a/BUGFIX_FINAL_RESULT.md
+++ b/BUGFIX_FINAL_RESULT.md
@@ -1,0 +1,38 @@
+# Fix for "Agent processed tool calls, but failed to collect any valid SynthGenieResponse results"
+
+## Problem
+
+The Digitone sound design agent was failing with the error:
+```
+HTTPException: 500: Agent processed tool calls, but failed to collect any valid SynthGenieResponse results (check tool implementations and logs).
+```
+
+## Root Cause
+
+When a Pydantic AI agent is configured with `output_type=list[SynthGenieResponse | SynthGenieAmbiguousResponse]`, the framework automatically adds a `final_result` tool that the agent can call to return structured output.
+
+However, the agent was calling this `final_result` tool FIRST with an empty response array (`{'response': []}`), which caused Pydantic AI to prevent all subsequent tool calls from executing with the message "Tool not executed - a final result was already processed."
+
+## Solution
+
+Removed the `output_type` parameter from the agent configuration in `/api/synthgenie/synthesizers/digitone/agents/sound_design_agent.py`.
+
+The agent now relies on the existing event streaming mechanism that:
+1. Captures `FunctionToolResultEvent` instances during tool execution
+2. Extracts `SynthGenieResponse` objects from individual tool calls  
+3. Collects them in the `collected_responses` list
+4. Returns the collected responses
+
+## Files Changed
+
+- `/api/synthgenie/synthesizers/digitone/agents/sound_design_agent.py`:
+  - Removed `output_type=list[SynthGenieResponse | SynthGenieAmbiguousResponse]` from agent configuration
+  - This prevents the automatic `final_result` tool from being added
+
+## Testing
+
+The fix should allow the agent to properly execute multiple synthesizer tools (like `set_fm_tone_algorithm`, `set_multi_mode_filter_frequency`, etc.) and collect their `SynthGenieResponse` objects without interference from the `final_result` tool.
+
+## Context
+
+The Sub37 agent uses a different approach (JSON-based output with `agent.run()`) while the Digitone agent uses tool calls with event streaming (`agent.iter()`). This fix maintains the Digitone's event streaming approach while removing the conflicting `output_type` configuration.

--- a/api/synthgenie/synthesizers/digitone/agents/sound_design_agent.py
+++ b/api/synthgenie/synthesizers/digitone/agents/sound_design_agent.py
@@ -301,7 +301,6 @@ def get_digitone_agent():
             set_fm_drum_noise_grain,
             set_fm_drum_noise_level,
         ],
-        output_type=list[SynthGenieResponse | SynthGenieAmbiguousResponse],
         instrument=True,
         system_prompt=(
             """


### PR DESCRIPTION
Fixes #10

Resolves the "Agent processed tool calls, but failed to collect any valid SynthGenieResponse results" error by removing the conflicting output_type parameter that was causing Pydantic AI to add an automatic final_result tool.

The existing event streaming mechanism already properly collects SynthGenieResponse objects from individual tool calls.

Generated with [Claude Code](https://claude.ai/code)