### PR TITLE
feat(midi): Filter devices and auto-select first supported synth

### DIFF
--- a/api/synthgenie/app.py
+++ b/api/synthgenie/app.py
@@ -42,6 +42,9 @@ app = FastAPI(
     version='1.0.0',
 )
 
+# Instrument FastAPI with Logfire
+logfire.instrument_fastapi(app)
+
 # Get base URL from environment
 base_url = os.getenv('BASE_URL', 'synthgenie.com')
 


### PR DESCRIPTION
The MIDI device selection logic has been updated to prevent users from selecting unsupported devices that cannot receive SysEx patch data.

Previously, the application would list and auto-select any available MIDI output. This change introduces filtering to ensure only supported synthesizers (e.g., Digitone, Sub37) are presented to the user and eligible for auto-selection.

- The `useMidi` hook now filters the device list using `detectSynthType`.
- Auto-selection defaults to the first valid synthesizer found.
- If no supported device is connected, the selection is cleared.

Additionally, this commit instruments the FastAPI backend with Logfire for enhanced logging and observability.